### PR TITLE
Adding secrets export and inline encryption

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,5 +193,14 @@ e.g.
 {{ LookupSecret "secret/bar" "alternate/path/bar" }}
 ```
 
-
+### Encryption
 This tool also includes file encryption that will allow you to encrypt the config files if they include sensitive information, this uses AES-256 CFB encryption and HMAC authenticaion from the Golang crypto library. This requires a 32 byte password that can be automatically generated if required.
+
+To generate an encryption key use, this is a random 32bytes encoded to base64
+```text
+vault-config keygen
+Key: ntOrOotr8lcst7vJ8/VLseSaPVGGcAGZDZmnmDUQBa8=
+
+```
+
+To encrypt an entire file

--- a/README.md
+++ b/README.md
@@ -12,6 +12,8 @@ Vault configuration for this tool will use the following environment variables
 
 The default Vault variables can also be configured and will be used for getting secret information from an existing Vault server, see template section for more information
 
+Exported secrets will be converted to base64 strings to prevent issues with multiline strings or quotes in values
+
 ### Resources
 #### Secret
 This resource will add secrets to the vault server

--- a/cmd/cmd_test.go
+++ b/cmd/cmd_test.go
@@ -3,11 +3,14 @@ package cmd
 import (
 	"testing"
 
+	"log"
+
 	"github.com/stretchr/testify/assert"
 )
 
 func TestExecute(t *testing.T) {
 	err := RootCmd.Execute()
+	log.Println(err)
 
 	assert.NoError(t, err, "Running configCmd should return no error")
 }

--- a/cmd/export.go
+++ b/cmd/export.go
@@ -96,6 +96,7 @@ to quickly create a Cobra application.`,
 					log.Fatalf("Error decoding base64 key: %v", key)
 				}
 			}
+			e.Key = decodedKey
 
 			err = e.InlineEncryptMap("secret/data")
 			if err != nil {

--- a/cmd/export.go
+++ b/cmd/export.go
@@ -1,0 +1,130 @@
+// Copyright © 2017 Sam Elliott <me@sam-e.co.uk>
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cmd
+
+import (
+	"encoding/base64"
+	"fmt"
+	"io/ioutil"
+	"log"
+	"os"
+	"strconv"
+
+	"github.com/elliottsam/vault-config/crypto"
+	"github.com/elliottsam/vault-config/template"
+	"github.com/elliottsam/vault-config/vault"
+	"github.com/hashicorp/hcl/hcl/printer"
+	"github.com/hashicorp/vault/api"
+	"github.com/spf13/cobra"
+)
+
+var (
+	path       string
+	generate   bool
+	decodedKey []byte
+)
+
+const secret_tmpl = `
+{{ range . }}
+{{ LookupSecret . }}
+{{ end }}
+`
+
+var e crypto.EncryptionObject
+
+// exportCmd represents the export command
+var exportCmd = &cobra.Command{
+	Use:   "export",
+	Short: "Export walks a path and exports secrets",
+	Long: `A longer description that spans multiple lines and likely contains examples
+and usage of using your command. For example:
+
+Cobra is a CLI library for Go that empowers applications.
+This application is a tool to generate the needed files
+to quickly create a Cobra application.`,
+	Run: func(cmd *cobra.Command, args []string) {
+		if path == "" {
+			log.Fatal("Please supply a Vault path with the -path parameter")
+		}
+
+		c := api.DefaultConfig()
+		if tlsSkipVerify, ok := os.LookupEnv("VAULT_SKIP_VERIFY"); ok {
+			if tlsSVBool, err := strconv.ParseBool(tlsSkipVerify); err != nil {
+				log.Fatal("Error parsing VAULT_SKIP_VERIFY boolean")
+			} else {
+				c.ConfigureTLS(&api.TLSConfig{Insecure: tlsSVBool})
+			}
+		}
+		client, err := vault.NewClient(c)
+		if err != nil {
+			log.Fatal("Error creating Vault client")
+		}
+
+		sPath, err := client.WalkVault(path)
+		if err != nil {
+			log.Fatal(err)
+		}
+
+		tmpl := template.InitGenerator("", []byte(secret_tmpl))
+		for _, v := range sPath {
+			tmpl.UpdateVarsMap(v, v)
+		}
+		e.PlainText = tmpl.GenerateConfig()
+
+		if encrypted {
+
+			if generate {
+				decodedKey = crypto.RandomKey(32)
+				log.Printf("Generated Key: %s\n", base64.StdEncoding.EncodeToString(decodedKey))
+			} else if key == "" {
+				log.Fatalf("Error: No encryption key supplied, either provide key or generate")
+			} else {
+				decodedKey, err = base64.StdEncoding.DecodeString(key)
+				if err != nil {
+					log.Fatalf("Error decoding base64 key: %v", key)
+				}
+			}
+
+			err = e.InlineEncryptMap("secret/data")
+			if err != nil {
+				log.Fatalf("Error encrypting Vault Config: %v", err)
+			}
+			e.PlainText = e.CipherText
+		}
+
+		e.PlainText, err = printer.Format(e.PlainText)
+		if err != nil {
+			log.Fatalf("Error formatting vault-config: %v", err)
+		}
+
+		if output == "" {
+			fmt.Println(string(e.PlainText))
+		} else {
+			if err := ioutil.WriteFile(output, e.PlainText, 0600); err != nil {
+				log.Fatalf("Error writing vault config to file: %v", err)
+			}
+		}
+	},
+}
+
+func init() {
+	RootCmd.AddCommand(exportCmd)
+
+	exportCmd.Flags().StringVarP(&path, "path", "p", "", "Path to retrieve secrets from")
+	exportCmd.Flags().BoolVarP(&encrypted, "encrypted", "e", false, "Should output be encrypted?")
+	exportCmd.Flags().StringVarP(&key, "key", "k", "", "Encryption key this must be 32 bytes")
+	exportCmd.Flags().BoolVarP(&generate, "generate", "g", false, "Generate encyption key at runtime")
+	exportCmd.Flags().StringVarP(&output, "output", "o", "", "Filename to output configuration to")
+}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -73,17 +73,6 @@ func init() {
 	}
 	viper.AutomaticEnv()
 	viper.SetEnvPrefix("vc")
-	if !viper.IsSet("vault_addr") {
-		RootCmd.Help()
-	}
 	vcVaultAddr = viper.GetString("vault_addr")
-	if !viper.IsSet("vault_token") {
-		RootCmd.Help()
-	}
 	vcVaultToken = viper.GetString("vault_token")
-	if viper.IsSet("vault_skip_verify") {
-		vcVaultSkipVerify = viper.GetBool("vault_skip_verify")
-	} else {
-		vcVaultSkipVerify = false
-	}
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -16,7 +16,6 @@ package cmd
 
 import (
 	"fmt"
-	"os"
 
 	"github.com/elliottsam/github"
 	"github.com/elliottsam/vault-config/version"
@@ -60,10 +59,7 @@ from another Vault server, see the README for more information`,
 // Execute adds all child commands to the root command sets flags appropriately.
 // This is called by main.main(). It only needs to happen once to the rootCmd.
 func Execute() {
-	if err := RootCmd.Execute(); err != nil {
-		fmt.Println(err)
-		os.Exit(-1)
-	}
+	RootCmd.Help()
 }
 
 func init() {

--- a/crypto/crypto.go
+++ b/crypto/crypto.go
@@ -228,7 +228,6 @@ func EncryptString(data string, key []byte) (string, error) {
 	stream.XORKeyStream(e.CipherText[aes.BlockSize:], e.PlainText)
 	e.HMAC, err = CreateHMAC(e.Key, e.CipherText)
 
-	//return fmt.Sprintf("@encrypted_data(%s)", base64.StdEncoding.EncodeToString(ct)), nil
 	e.WrapCrypto()
 	return fmt.Sprintf("@encrypted_data(%s)", base64.StdEncoding.EncodeToString([]byte(e.WrappedData))), nil
 }
@@ -249,10 +248,6 @@ func DecryptString(WrappedText string, key []byte) (string, error) {
 		return "", fmt.Errorf("decoding base64 cipher: %v", err)
 	}
 
-	//b64wrap, err := base64.StdEncoding.DecodeString(e.WrappedData)
-	//if err != nil {
-	//	return "", fmt.Errorf("Decoding base64 encoded wrapped data")
-	//}
 	e.WrappedData = string(b64wrap)
 	e.UnwrapCrypto()
 

--- a/crypto/crypto_test.go
+++ b/crypto/crypto_test.go
@@ -3,6 +3,7 @@ package crypto
 import (
 	"testing"
 
+	"github.com/hashicorp/hcl"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -10,7 +11,21 @@ const (
 	str         = `This is a test string`
 	cipherRegex = `@encrypted_data\((.*)\)`
 	hmacRegex   = `@hmac\((.*)\)`
+	secretHCL   = `secret "test" {
+  path = "secret/test"
+
+  data {
+    value  = "test_value1"
+    value2 = "test_value2"
+  }
+}`
 )
+
+type secret struct {
+	Name string                 `hcl:",key"`
+	Path string                 `hcl:"path"`
+	Data map[string]interface{} `hcl:"data"`
+}
 
 var (
 	key = []byte{153, 43, 36, 168, 16, 188, 230, 176, 58, 230, 90, 31, 60, 230, 144, 113, 91, 99, 142, 113, 201, 215, 170, 200, 251, 250, 234, 101, 249, 1, 194, 171}
@@ -49,4 +64,37 @@ func TestRandomKey(t *testing.T) {
 	b := RandomKey(32)
 	assert.Equal(t, 32, len(a), "Length of generated string should be 32")
 	assert.NotEqual(t, a, b, "Two different keys should not be the same")
+}
+
+func TestStringEncryption(t *testing.T) {
+	es, err := EncryptString(str, key)
+	assert.NoError(t, err, "No error should occur when encrypting string")
+	assert.Regexp(t, cipherRegex, es, "Cipher text should match regex")
+	ps, err := DecryptString(es, key)
+	assert.NoError(t, err, "No error should occur when decrypting string")
+	assert.Equal(t, str, ps, "Decrypted string should match original string")
+}
+
+func TestInlineEncryptSecrets(t *testing.T) {
+	var (
+		originalObject  secret
+		encryptedObject secret
+	)
+	e := EncryptionObject{
+		Key:       key,
+		PlainText: []byte(secretHCL),
+	}
+	hcl.Unmarshal([]byte(secretHCL), &originalObject)
+
+	err := e.InlineEncryptMap("string/data")
+	assert.NoError(t, err, "No error should occur whilst encrypting data")
+	hcl.Unmarshal(e.CipherText, &encryptedObject)
+
+	for k, v := range encryptedObject.Data {
+		assert.Regexp(t, cipherRegex, v.(string), "Values should have been encrypted")
+		v, err = DecryptString(v.(string), key)
+		assert.NoError(t, err, "No errors should occur decrypting string")
+		assert.Equal(t, originalObject.Data[k], v, "After decryption values should match")
+	}
+	assert.Equal(t, originalObject, encryptedObject, "Secre objects should match")
 }

--- a/crypto/inline.go
+++ b/crypto/inline.go
@@ -1,0 +1,66 @@
+package crypto
+
+import (
+	"bytes"
+	"fmt"
+	"log"
+	"strings"
+
+	"github.com/hashicorp/hcl"
+	"github.com/hashicorp/hcl/hcl/ast"
+	"github.com/hashicorp/hcl/hcl/printer"
+)
+
+func (e *EncryptionObject) InlineEncryptMap(path string) error {
+	astFile, err := hcl.ParseBytes(e.PlainText)
+	if err != nil {
+		return fmt.Errorf("Error parsing HCL into *ast.File: %v", err)
+	}
+
+	data := findKeyInObject(astFile.Node.(*ast.ObjectList).Items, path)
+	for _, v := range data {
+		if !wrappedCipherRegex.MatchString(v.Val.(*ast.LiteralType).Token.Text) {
+			s, err := EncryptString(strings.Trim(v.Val.(*ast.LiteralType).Token.Text, "\""), e.Key)
+			if err != nil {
+				return fmt.Errorf("Error encrypting string: %v", err)
+			}
+			v.Val.(*ast.LiteralType).Token.Text = fmt.Sprintf("\"%s\"", s)
+		} else {
+			log.Printf("Key: %v appears to already be encrypted, skipping inline encryption", v.Keys[0].GoString())
+		}
+	}
+
+	var buf bytes.Buffer
+	if err := printer.Fprint(&buf, astFile); err != nil {
+		return fmt.Errorf("Error writing to buffer: %v", err)
+	}
+
+	e.CipherText = buf.Bytes()
+
+	return nil
+}
+
+func findKeyInObject(obj []*ast.ObjectItem, key string) []*ast.ObjectItem {
+	ks := strings.Split(key, "/")
+	for _, k := range ks {
+		var loopObj []*ast.ObjectItem
+		for _, v := range obj {
+			if keysContain(v.Keys, k) {
+				loopObj = append(loopObj, v.Val.(*ast.ObjectType).List.Items...)
+			}
+		}
+		obj = loopObj
+	}
+
+	return obj
+}
+
+func keysContain(k []*ast.ObjectKey, value string) bool {
+	for _, v := range k {
+		if v.Token.Text == value {
+			return true
+		}
+	}
+
+	return false
+}

--- a/template/template.go
+++ b/template/template.go
@@ -104,6 +104,7 @@ func (g *Generator) GenerateConfig() []byte {
 func (g *Generator) readVars(filename string) {
 	_, err := os.Stat(filename)
 	if err != nil {
+		g.vars = make(map[string]interface{})
 		return
 	}
 	vars, err := ioutil.ReadFile(filename)
@@ -114,4 +115,8 @@ func (g *Generator) readVars(filename string) {
 	if err := hcl.Unmarshal(vars, &g.vars); err != nil {
 		panic(err)
 	}
+}
+
+func (g *Generator) UpdateVarsMap(key, value string) {
+	g.vars[key] = value
 }

--- a/template/template.go
+++ b/template/template.go
@@ -2,6 +2,7 @@ package template
 
 import (
 	"bytes"
+	"encoding/base64"
 	"fmt"
 	"io/ioutil"
 	"os"
@@ -52,6 +53,11 @@ func (g *Generator) templateLookupSecret(path string, targetPath ...string) (int
 	if err != nil || s == nil {
 		return nil, fmt.Errorf("reading from vault path: %s\nError: %v", path, err)
 	}
+	for k, v := range s.Data {
+		base64.StdEncoding.EncodeToString([]byte(v.(string)))
+		s.Data[k] = fmt.Sprintf("@base64(%s)", base64.StdEncoding.EncodeToString([]byte(v.(string))))
+	}
+
 	tmplSecret := secret{
 		Path: path,
 		Data: s.Data,

--- a/vault/secrets.go
+++ b/vault/secrets.go
@@ -1,6 +1,13 @@
 package vault
 
-import "fmt"
+import (
+	"fmt"
+	"regexp"
+
+	"github.com/elliottsam/vault-config/crypto"
+)
+
+var wrappedCipherRegex = regexp.MustCompile(`@encrypted_data\((.*)\)`)
 
 type Secret struct {
 	Name string                 `hcl:",key"`
@@ -24,4 +31,46 @@ func (c *VCClient) secretExist(s Secret) bool {
 	}
 
 	return true
+}
+
+func (c *Config) DecryptSecrets(key []byte) error {
+	var err error
+	for _, s := range c.Secrets {
+		for k, v := range s.Data {
+			switch v.(type) {
+			case string:
+				if wrappedCipherRegex.MatchString(v.(string)) {
+					s.Data[k], err = crypto.DecryptString(v.(string), key)
+					if err != nil {
+						return fmt.Errorf("Error decrypting secret: %s\nErr: %v", s.Path, err)
+					}
+				}
+			}
+		}
+	}
+	return nil
+}
+
+// SecretsEncrypted will search a slice of secrets for encryption strings and return true if found
+func SecretsEncrypted(c Config) (sf bool) {
+	for _, v := range c.Secrets {
+		for _, v := range v.Data {
+			switch v.(type) {
+			case string:
+				if wrappedCipherRegex.MatchString(v.(string)) {
+					sf = true
+				}
+			}
+		}
+	}
+	for _, v := range c.Auth.Ldap.AuthConfig {
+		switch v.(type) {
+		case string:
+			if wrappedCipherRegex.MatchString(v.(string)) {
+				sf = true
+			}
+		}
+	}
+
+	return
 }

--- a/vault/vault_init_test.go
+++ b/vault/vault_init_test.go
@@ -76,13 +76,13 @@ func (v *vaultServerConfigTestSuite) killVaultServer() {
 func (v *vaultServerConfigTestSuite) initVaultTestClient() {
 	conf := api.DefaultConfig()
 	conf.Address = v.vaultAddress
-	c, err := api.NewClient(conf)
+	c, err := NewClient(conf)
 	if err != nil {
 		v.T().Fatalf("Error creating Vault client: %v", err)
 	}
 	c.SetToken(v.vaultToken)
 
-	v.vtc = &VCClient{c}
+	v.vtc = c
 }
 
 func TestVaultServerConfigTestSuite(t *testing.T) {
@@ -188,6 +188,22 @@ secret "test" {
 	data {
 		value = "test1"
 		password = "test2"
+	}
+}
+
+secret "test2" {
+	path = "/example/app1/test/foo/bar"
+	data {
+		value = "foo"
+		password = "bar"
+	}
+}
+
+secret "test" {
+	path = "/example/app1/bar/foo/bar/foo"
+	data {
+		value = "bar"
+		password = "foo"
 	}
 }`
 

--- a/vault/vault_test.go
+++ b/vault/vault_test.go
@@ -74,9 +74,10 @@ func (vsc *vaultServerConfigTestSuite) TestVCClient_MountsAndSecrets() {
 		amttl, _ := time.ParseDuration(fmt.Sprintf("%ss", mt["max_lease_ttl"].(json.Number)))
 		assert.Equal(vsc.T(), emttl, amttl, "mttl should be equal to value from configuration")
 	} else {
-		vsc.T().Errorf("No mount found: %v")
+		vsc.T().Errorf("No mount found: %v", mount.Path)
 	}
 
+	// Test adding secrets to the vault server
 	for _, v := range vc.Secrets {
 		assert.False(vsc.T(), vsc.vtc.secretExist(v), "Secret should not exist before write: %s", v.Name)
 		err := vsc.vtc.WriteSecret(v)
@@ -86,6 +87,11 @@ func (vsc *vaultServerConfigTestSuite) TestVCClient_MountsAndSecrets() {
 		assert.NoError(vsc.T(), err, "Reading secret path should not return an error: %s", v.Name)
 		assert.Equal(vsc.T(), v.Data, secret.Data, "Secret should match input: %s", v.Name)
 	}
+
+	// Test walking vault secret mount
+	vwo, err := vsc.vtc.WalkVault("example/app1")
+	assert.NoError(vsc.T(), err, "Walking Vault should not generate any errors")
+	assert.Equal(vsc.T(), 3, len(vwo), "Walk should return 3 paths")
 }
 
 func (vsc *vaultServerConfigTestSuite) TestVCClient_Policy() {

--- a/version/version.go
+++ b/version/version.go
@@ -1,4 +1,4 @@
 package version
 
 // Version of the program
-const Version = `0.3.1`
+const Version = `0.4.0`


### PR DESCRIPTION
This adds the ability to export secrets from an secret mount and then allow import into a new server
Exported secrets are base64 encoded to remove potential issue for errors with newlines or quotes
Encryption now supports inline encryption as well as full file, exported secrets will only use inline encryption